### PR TITLE
fix: compatible with derive_more 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,21 +942,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
  "unicode-xid",
 ]
@@ -1050,7 +1061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2419,7 +2430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2432,7 +2443,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2951,7 +2962,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3279,6 +3290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,7 +3475,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 console = "0.15"
 ctrlc = "3"
-derive_more = { version = "2.0", features = ["display", "from", "deref", "deref_mut", "into", "as_ref"] }
+derive_more = { version = "2.1", features = ["display", "from", "deref", "deref_mut", "into", "as_ref"] }
 directories = "6"
 generic-array = "0.14"
 hex = "0.4"

--- a/crates/lib/src/cryptography/authorization_tag.rs
+++ b/crates/lib/src/cryptography/authorization_tag.rs
@@ -1,16 +1,21 @@
 use std::str::FromStr;
 
 use aes_gcm::Tag;
-use derive_more::{AsMut, AsRef, From};
+use derive_more::{AsMut, From};
 use generic_array::GenericArray;
 
 use crate::*;
 
-#[derive(AsRef, AsMut, From)]
+#[derive(AsMut, From)]
 #[as_mut([u8])]
-#[as_ref[Tag<C::AuthorizationTagSize>]]
 #[impl_tools::autoimpl(Debug, PartialEq)]
 pub struct AuthorizationTag<C: Cipher>(GenericArray<u8, C::AuthorizationTagSize>);
+
+impl<C: Cipher> AsRef<Tag<C::AuthorizationTagSize>> for AuthorizationTag<C> {
+    fn as_ref(&self) -> &Tag<C::AuthorizationTagSize> {
+        &self.0
+    }
+}
 
 impl<C: Cipher> FromStr for AuthorizationTag<C> {
     type Err = Base64DecodeError;


### PR DESCRIPTION
## Summary

The `derive_more` 2.1.0 release includes a fix for "Missing trait bounds in `AsRef`/`AsMut` derives when associative types are involved" ([#474](https://github.com/JelteF/derive_more/pull/474)).

This fix adds additional where clauses to the generated impl blocks that require `GenericArray` to implement `AsRef` for itself, which it doesn't. This causes a compilation error in `rops`:

```
error[E0599]: the method `as_ref` exists for reference `&authorization_tag::AuthorizationTag<aes256_gcm::AES256GCM>`, but its trait bounds were not satisfied
  --> crates/lib/src/cryptography/cipher/aes256_gcm.rs:46:31
   |
46 |             authorization_tag.as_ref(),
   |                               ^^^^^^ method cannot be called due to unsatisfied trait bounds
```

This PR replaces the derived `AsRef` with a manual implementation to avoid the trait bound issue while maintaining the same functionality.

## Changes

- Remove `AsRef` from the derive macro on `AuthorizationTag`
- Add manual `impl AsRef<Tag<C::AuthorizationTagSize>> for AuthorizationTag<C>`

## Test Plan

- All 128 lib tests pass
- All 7 parity tests pass

This was discovered when mise's lockfile maintenance PR updated `derive_more` from 2.0.1 to 2.1.0: https://github.com/jdx/mise/pull/7211

🤖 Generated with [Claude Code](https://claude.com/claude-code)